### PR TITLE
Use OpenFileDialog for OpenImage in AreaDesigner

### DIFF
--- a/HearthCap/Features/Diagnostics/AreaDesigner/AreaDesignerViewModel.cs
+++ b/HearthCap/Features/Diagnostics/AreaDesigner/AreaDesignerViewModel.cs
@@ -408,7 +408,7 @@
 
         public void OpenImage()
         {
-            var dlg = new Microsoft.Win32.SaveFileDialog
+            var dlg = new Microsoft.Win32.OpenFileDialog
                           {
                               FileName = "area", 
                               DefaultExt = ".png", 


### PR DESCRIPTION
This avoids the overwrite confirmation dialog when an image file has been
selected.