### PR TITLE
Deck Screenshot HACK

### DIFF
--- a/HearthCap.Core/GameCapture/HS/HSImageScanner.cs
+++ b/HearthCap.Core/GameCapture/HS/HSImageScanner.cs
@@ -812,7 +812,7 @@ namespace HearthCap.Core.GameCapture.HS
             if (deckScreenshotRequested)
             {
                 var detect1 = Detect(this.areas, "deckscreen");
-                var detect2 = Detect(this.areas, "deckscreen2");
+                var detect2 = Detect(this.areas, "deckscreen2", null, 16);
                 if (detect1 && detect2)
                 {
                     this.deckScreenshotRequested = false;

--- a/HearthCap.Core/data/areas.json
+++ b/HearthCap.Core/data/areas.json
@@ -986,7 +986,7 @@
         "Y": 0,
         "Height": 90,
         "Width": 48,
-        "Hash": 283974106150120085,
+        "Hash": 2554853933014887253,
         "Image": null,
         "BaseResolution": 0,
         "Mostly": "Red"


### PR DESCRIPTION
This is an HACK (not a good one) to get deck screen-shot working.

Since i doesn't understand where the image detection is to modify it more precisely, I've just increase the threshold to 16. The default value is 9.

EDIT : I finally understood ! just import new areas.json